### PR TITLE
Seqlengths fixes

### DIFF
--- a/R/allClasses.r
+++ b/R/allClasses.r
@@ -34,7 +34,8 @@
 #' @param removeDup Remove duplicates before calculating coverage.
 #' @param verbose TRUE or FALSE
 #' @param format character vector of "BAM", "BigWig", "RleList" or "PWM"
-#' @param seqlengths Chromosomes to be used. If missing will report all.
+#' @param seqlengths A named vector of seqlengths of chromosomes to be used, e.g. 
+#' from a BSgenome object. If missing will report all.
 #' @param forceFragment Centre fragment and force consistent fragment width.
 #' @param method Character vector of value "bp","bin" or "spline". 
 #' The bin method divides a region of interest into equal sized bins of number specified in nOfWindows.

--- a/R/plots.R
+++ b/R/plots.R
@@ -76,10 +76,15 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
       
       if(!is.null(outliers)){
         profileTempList <- lapply(gts,function(x)
-          colMeans(winsorizeMatrix(subsetProfile(profileTemp,x,rowData(object),summariseBy),outliers,1-outliers))
+          mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
+          if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
+          colMeans(winsorizeMatrix(mat,outliers,1-outliers, na.rm = TRUE), na.rm = TRUE)
           )         
       }else{
-        profileTempList <- lapply(gts,function(x)colMeans(subsetProfile(profileTemp,x,rowData(object),summariseBy))) 
+        profileTempList <- lapply(gts,function(x){
+          mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy))
+          if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
+          colMeans(mat, na.rm = TRUE) }
       }
     
     ## Create melted data frame for ggplot and attach index
@@ -125,10 +130,16 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
           names(gts) <- unlist(gts)
           if(!is.null(outliers)){
             profileTempList <- lapply(gts,function(x)
-              colMeans(winsorizeMatrix(subsetProfile(profileTemp,x,rowData(object),summariseBy),outliers,1-outliers))
+              mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
+              if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
+              colMeans(winsorizeMatrix(mat,outliers,1-outliers, na.rm = TRUE), na.rm = TRUE)
             )         
           }else{
-            profileTempList <- lapply(gts,function(x)colMeans(subsetProfile(profileTemp,x,rowData(object),summariseBy))) 
+            profileTempList <- lapply(gts,function(x){
+              mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy))
+              if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
+              colMeans(mat, na.rm = TRUE) 
+            }
           }
       
     
@@ -164,11 +175,14 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
     ## windsorised colmeans of whole profile matrix
     
     if(!is.null(outliers)){
-      profileList <- lapply(c(assays(object)),function(x)
-        colMeans(winsorizeMatrix(x,outliers,1-outliers))
-      )         
-    }else{    
-      profileList <- lapply(c(assays(object)),colMeans)
+      profileList <- lapply(c(assays(object)),function(x) {
+        if(any(is.na(x))){warning("NAs present in assays; removing them when creating average profile")}
+        colMeans(winsorizeMatrix(x,outliers,1-outliers, na.rm = TRUE), na.rm = TRUE)
+      })         
+    }else{
+      profileList <- lapply(c(assays(object)),function(x) {
+        if(any(is.na(x))){warning("NAs present in assays; removing them when creating average profile")}
+           colMeans(x, na.rm = TRUE)})
     }
     
     ## Join multiple assays/samples
@@ -291,11 +305,11 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
   return(P)
 }
 
-winsorizeMatrix <- function(mat,limitlow,limithigh){
-  apply(mat,2,function(x)winsorizeVector(x,limitlow,limithigh))
+winsorizeMatrix <- function(mat,limitlow,limithigh, na.rm = FALSE){
+  apply(mat,2,function(x)winsorizeVector(x,limitlow,limithigh, na.rm = na.rm))
 }
-winsorizeVector <- function(vect,limitlow,limithigh){
-  qs <- quantile(vect,c(limitlow,limithigh))
+winsorizeVector <- function(vect,limitlow,limithigh, na.rm = FALSE){
+  qs <- quantile(vect,c(limitlow,limithigh), na.rm = na.rm)
   vect[vect < qs[1]] <- qs[1]  
   vect[vect > qs[2]] <- qs[2]  
   vect

--- a/R/plots.R
+++ b/R/plots.R
@@ -75,16 +75,16 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
     ## Alternatively windsoring (see method) of subsets then colmeans.
       
       if(!is.null(outliers)){
-        profileTempList <- lapply(gts,function(x)
+        profileTempList <- lapply(gts,function(x){
           mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
           if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
           colMeans(winsorizeMatrix(mat,outliers,1-outliers, na.rm = TRUE), na.rm = TRUE)
-          )         
+          })
       }else{
         profileTempList <- lapply(gts,function(x){
-          mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy))
+          mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
           if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
-          colMeans(mat, na.rm = TRUE) }
+          colMeans(mat, na.rm = TRUE) })
       }
     
     ## Create melted data frame for ggplot and attach index
@@ -129,17 +129,17 @@ plotRegion.ChIPprofile <- function(object,gts=NULL,sampleData=NULL,groupData=NUL
           summariseBy <- "summariseCol"
           names(gts) <- unlist(gts)
           if(!is.null(outliers)){
-            profileTempList <- lapply(gts,function(x)
+            profileTempList <- lapply(gts,function(x){
               mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
               if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
               colMeans(winsorizeMatrix(mat,outliers,1-outliers, na.rm = TRUE), na.rm = TRUE)
-            )         
+            })         
           }else{
             profileTempList <- lapply(gts,function(x){
-              mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy))
+              mat <- subsetProfile(profileTemp,x,rowData(object),summariseBy)
               if(any(is.na(mat))){warning("NAs present in assays; removing them when creating average profile")}
               colMeans(mat, na.rm = TRUE) 
-            }
+            })
           }
       
     

--- a/R/tracktables.R
+++ b/R/tracktables.R
@@ -240,7 +240,7 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
   ##  Calculate fragment length from cross-coverage if not provided
   
     if(paired==FALSE){
-      total <- readGAlignmentsFromBam(bamFile,param=Param)
+      total <- readGAlignments(bamFile,param=Param)
       message("..Done.\nRead in ",length(total)," reads")
       
       if(is.null(FragmentLength)){
@@ -257,7 +257,7 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
   
     if(paired==TRUE){
       
-      gaPaired <- readGAlignmentsFromBam(bamFile, 
+      gaPaired <- readGAlignments(bamFile, 
                                          param=ScanBamParam(what=c("mpos"),
                                                             flag=scanBamFlag(isProperPair = TRUE,isFirstMateRead = TRUE)))      
       tempPos <- GRanges(seqnames(gaPaired[strand(gaPaired) == "+"]),

--- a/R/tracktables.R
+++ b/R/tracktables.R
@@ -92,7 +92,10 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
     if(is.null(seqlengths)){
       seqlengths(genomeCov) <- unlist(lapply(genomeCov,length))
     }else{
-      seqlengths(genomeCov)[match(names(seqlengths),names(genomeCov))] <- seqlengths
+      allchrs <- intersect(names(seqlengths), names(genomeCov))
+      if (length(allchrs)==0){ error("No overlapping chromosomes between coverage and supplied seqlengths") }
+      genomeCov <- genomeCov[allchrs] #subset to get only desired chrs
+      seqlengths(genomeCov)[allchrs] <- seqlengths[allchrs] #set seqlengths
     }
     lengths <- seqlengths(genomeCov)
     allchrs <- names(lengths)
@@ -121,7 +124,10 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
     if(is.null(seqlengths)){
       seqlengths(genomeCov) <- unlist(lapply(genomeCov,length))
     }else{
-      seqlengths(genomeCov)[match(names(seqlengths),names(genomeCov))] <- seqlengths
+      allchrs <- intersect(names(seqlengths), names(genomeCov))
+      if (length(allchrs)==0){ error("No overlapping chromosomes between coverage and supplied seqlengths") }
+      genomeCov <- genomeCov[allchrs] #subset to get only desired chrs
+      seqlengths(genomeCov)[allchrs] <- seqlengths[allchrs] #set seqlengths
     }
     lengths <- seqlengths(genomeCov)
     allchrs <- names(lengths)

--- a/R/tracktables.R
+++ b/R/tracktables.R
@@ -92,7 +92,7 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
     if(is.null(seqlengths)){
       seqlengths(genomeCov) <- unlist(lapply(genomeCov,length))
     }else{
-      seqlengths(genomeCov)[match(names(lengths),names(genomeCov))] <- lengths
+      seqlengths(genomeCov)[match(names(seqlengths),names(genomeCov))] <- seqlengths
     }
     lengths <- seqlengths(genomeCov)
     allchrs <- names(lengths)
@@ -121,7 +121,7 @@ runRegionPlot <- function(bamFile,testRanges,samplename=NULL,nOfWindows=100,Frag
     if(is.null(seqlengths)){
       seqlengths(genomeCov) <- unlist(lapply(genomeCov,length))
     }else{
-      seqlengths(genomeCov)[match(names(lengths),names(genomeCov))] <- lengths
+      seqlengths(genomeCov)[match(names(seqlengths),names(genomeCov))] <- seqlengths
     }
     lengths <- seqlengths(genomeCov)
     allchrs <- names(lengths)


### PR DESCRIPTION
1. fixed the option to specify seqlengths use this to choose chrs to summarise 
2. also added functionality to summarise data even if the seqlengths extend beyond the coverage on the chromosome (this produces NAs in assays, which are dropped with a warning when plotting)

(alternative to 2 could be to replace NAs with zeroes? This might be more technically accurate when taking colMeans, but would be a little harder to implement)
